### PR TITLE
Tooltip

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 a simple collaborative text-based adventure platform designed for play be 2E
 
-for any feature requests or bug reports, open issues for this repo
+for any feature requests or bug reports, [open issues](https://github.com/jynnie/onionvale/issues) for this repo
 
 for a comprehensive documentation on how I designed/developed this application, check out 
 [documentation.md](https://github.com/jynnie/onionvale/blob/master/documentation.md)
@@ -18,6 +18,10 @@ and html injection, but with certain exceptions
 
 ## Development
 
-1. install Node.js
+1. install [Node.js](https://nodejs.org/en/download/) and [MongoDB](https://www.mongodb.com/download-center#community)
 2. `npm install` dependencies
-2. `npm start` to run local instance on `localhost:8080`
+3. `cp example.config.js config.js`
+4. set the appropraite environment variables in `config.js`
+4. `mkdir db`
+4. `mongod --dbpath db & # Have the mongo daemon run in the background`
+4. `npm start` to run local instance on `localhost:8080`

--- a/app.js
+++ b/app.js
@@ -12,8 +12,8 @@ const app = express();
 const PORT = 8080;
 
 // database connection
-mongoose.connect("mongodb://localhost/onionvale");
-// mongoose.connect(config.MONGOLAB_URI);
+//mongoose.connect("mongodb://localhost/onionvale");
+mongoose.connect(config.MONGOLAB_URI);
 var connection = mongoose.connection;
 connection.on("error", console.error.bind(console, "connection error:"));
 connection.on("connected", function() {

--- a/example.config.js
+++ b/example.config.js
@@ -1,4 +1,4 @@
 // example config file
-const MONGOLAB_URI = "mongodb://";
+const MONGOLAB_URI = "mongodb://localhost:27017";
 
 exports.MONGOLAB_URI = MONGOLAB_URI;

--- a/public/style.css
+++ b/public/style.css
@@ -249,6 +249,22 @@ span.fade {
   box-shadow: 0 5px 0 0 var(--black), 0 10px 0 0 var(--black);
 }
 
+.tooltip {
+  position: relative;
+} 
+
+.tooltip .tooltiptext {
+  display: none;
+  width: 140%;
+  padding-left: 0.5em;
+  font-style: italic;
+  z-index: 1;
+}
+
+.tooltip:hover .tooltiptext {
+  display: inline-block;
+}
+
 @keyframes wipe {
   from {
     width: 0;

--- a/views/index.pug
+++ b/views/index.pug
@@ -46,7 +46,7 @@ html
         ul
           li !player [text]
           li !game [text]
-          li !stat [name] [integer value]
+          li !stat [name] [integer value] [max value]
           li !item [name] [integer value] [optional descript]
                 
   footer

--- a/views/index.pug
+++ b/views/index.pug
@@ -44,10 +44,14 @@ html
       .sidebar
         .side-title controls
         ul
-          li !player [text]
-          li !game [text]
-          li !stat [name] [integer value] [max value]
-          li !item [name] [integer value] [optional descript]
+          li.tooltip !player [text] 
+            span.tooltiptext A player command (text preceeded by >)
+          li.tooltip !game [text]
+            span.tooltiptext A response to a command
+          li.tooltip !stat [name] [integer value] [max value]
+            span.tooltiptext Adds or modifies a stat
+          li.tooltip !item [name] [integer value] [optional descript]
+            span.tooltiptext Adds or changes the quantity an item
                 
   footer
     p a collaborative text RPG played by 2E


### PR DESCRIPTION
So I think I might have messed this PR up because I pushed to my fork but this depends on #4 (and kind of includes the changes from it here)

I tried adding tooltips to the game commands on the top right:
![onion](https://user-images.githubusercontent.com/6826622/42359334-36b67d58-80af-11e8-9087-db515c670cac.gif)

and this is what they look like in mobile
![onion-mobile](https://user-images.githubusercontent.com/6826622/42359338-3e1e99ea-80af-11e8-89b7-2efbf1e088cd.gif)

It would be nice to have something similar for the item description panel in the top left (though the same jank CSS code wouldn't be usable for those tooltips (I think partially because of the `display: flex` in the `item` class and the `tooltiptext` class using `display:inline-block`

Advice on making this better would be much appreciated.