### PR TITLE
Add jank tooltip to game commands sidebar

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -249,6 +249,22 @@ span.fade {
   box-shadow: 0 5px 0 0 var(--black), 0 10px 0 0 var(--black);
 }
 
+.tooltip {
+  position: relative;
+} 
+
+.tooltip .tooltiptext {
+  display: none;
+  width: 140%;
+  padding-left: 0.5em;
+  font-style: italic;
+  z-index: 1;
+}
+
+.tooltip:hover .tooltiptext {
+  display: inline-block;
+}
+
 @keyframes wipe {
   from {
     width: 0;

--- a/views/index.pug
+++ b/views/index.pug
@@ -44,10 +44,14 @@ html
       .sidebar
         .side-title controls
         ul
-          li !player [text]
-          li !game [text]
-          li !stat [name] [integer value]
-          li !item [name] [integer value] [optional descript]
+          li.tooltip !player [text] 
+            span.tooltiptext A player command (text preceeded by >)
+          li.tooltip !game [text]
+            span.tooltiptext A response to a command
+          li.tooltip !stat [name] [integer value] [max value]
+            span.tooltiptext Adds or modifies a stat
+          li.tooltip !item [name] [integer value] [optional descript]
+            span.tooltiptext Adds or changes the quantity an item
                 
   footer
     p a collaborative text RPG played by 2E


### PR DESCRIPTION
I think this PR is independent from #5, sorry about my bad Github practices.

I tried adding tooltips to the game commands on the top right:
![onion](https://user-images.githubusercontent.com/6826622/42359334-36b67d58-80af-11e8-9087-db515c670cac.gif)

and this is what they look like in mobile
![onion-mobile](https://user-images.githubusercontent.com/6826622/42359338-3e1e99ea-80af-11e8-89b7-2efbf1e088cd.gif)

It would be nice to have something similar for the item description panel in the top left (though the same jank CSS code wouldn't be usable for those tooltips (I think partially because of the `display: flex` in the `item` class and the `tooltiptext` class using `display:inline-block`

Advice on making this better would be much appreciated.