### PR TITLE
Fix bug with escaping underscores and asterisks when posting to discord

### DIFF
--- a/app.js
+++ b/app.js
@@ -71,7 +71,7 @@ app.set("view engine", "pug");
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(bodyParser.json());
 
-//routes
+// routes
 app.get("/", function(req, res) {
   readGameState(function() {
     res.render("index", {
@@ -309,6 +309,8 @@ function saveLogToGameState(newLog) {
  */
 function styleMsg(msg) {
   return msg
+    .replace(/_/gi, "\\_")
+    .replace(/\*/gi, "\\*")
     .replace(/<b>/gi, "**")
     .replace(/<\/b>/gi, "**")
     .replace(/<em>/gi, "_")


### PR DESCRIPTION
Posting to discord, now with escaped item names!

![image](https://user-images.githubusercontent.com/6826622/42957479-d35d960e-8b50-11e8-9ad0-f15bdc0be84e.png)

The item in questions was a `fork` btw, but changed to test escaping asterisks 