### PR TITLE
🎲Add dice rolls🎲

### DIFF
--- a/views/index.pug
+++ b/views/index.pug
@@ -49,6 +49,7 @@ html
           li !game [text]
           li !stat [name] [integer value] [max value]
           li !item [name] [integer value] [optional descript]
+          li !roll [num sides] [optional num dice]
                 
   footer
     p a collaborative text RPG played by 2E


### PR DESCRIPTION
This allows a player to use `!roll [numsides]` to roll 1 `numsides`-sided die or `!roll [numsides] [numdice]` to roll `numdice` `numsides`-sided dice.

What the message looks like in game:
![image](https://user-images.githubusercontent.com/6826622/43602645-8bf2454e-965e-11e8-9c3d-84be96b47fe8.png)

What the message looks like when posted to discord:
![image](https://user-images.githubusercontent.com/6826622/43602673-a3d95512-965e-11e8-98bb-ed727beadc0a.png)

Prevents negative sides, sides less than 2 (equivalent to a coin flip), negative dice, and dice numbers greater than **20** (to prevent the log from getting hijacked and filled with a silly number of dice rolls). If someone inputs a ridiculous number of sides, JS will turn that into `Infinity` and would at worst add 20 `Infinity` rolls to the log:
![image](https://user-images.githubusercontent.com/6826622/43602837-226449c8-965f-11e8-9b6d-1d22002b0eda.png)
